### PR TITLE
bump galera to MariaDB 10.1

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -8,7 +8,7 @@ class galera::repo {
       }
 
       apt::source { 'galera':
-        location => 'http://lon1.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/',
+        location => 'http://lon1.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu/',
         repos    => 'main',
       }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -33,7 +33,7 @@ class galera::server (
     install_options         => $install_options,
     manage_config_file      => $manage_config_file,
     override_options        => $override_options,
-    package_name            => 'mariadb-galera-server',
+    package_name            => 'mariadb-server',
     package_ensure          => $package_ensure,
     package_manage          => $package_manage,
     purge_conf_dir          => $purge_conf_dir,


### PR DESCRIPTION
Galera support is now built in to MariaDB 10.1, so no need to specify a different package.